### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/web/WEB-INF/lib/apache-log4j-2.6.2-src/apache-log4j-2.6.2-src/log4j-distribution/pom.xml
+++ b/web/WEB-INF/lib/apache-log4j-2.6.2-src/apache-log4j-2.6.2-src/log4j-distribution/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j</artifactId>
-    <version>2.6.2</version>
+    <version>2.17.0</version>
     <relativePath>../</relativePath>
   </parent>
   <artifactId>log4j-distribution</artifactId>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105